### PR TITLE
fix #11

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,6 +131,12 @@ module.exports = {
 			inject: 'body',
 			filename: 'index.html'
 		}),
+		new HtmlWebpackPlugin({
+			template: 'src/index.html',
+			language: applicationConfig.language,
+			inject: 'body',
+			filename: '404.html'
+		}),
 		new webpack.BannerPlugin({
 			banner: `Created: ${new Date().toUTCString()}`,
 			raw: false,


### PR DESCRIPTION
By default, pm2 displays 404.html from the serving directory if it can't map a request to any static file of that directory. so create a duplicate 404.html same like index.html will resolve the issue