### PR TITLE
Fixed condition issue allowing only 1 country.

### DIFF
--- a/src/modules/settings/shippingEdit/index.js
+++ b/src/modules/settings/shippingEdit/index.js
@@ -65,8 +65,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 				const countriesStr = method.conditions.countries;
 				method.conditions.countries = countriesStr
 					.split(',')
-					.map(item => item.trim().toUpperCase())
-					.filter(item => item.length === 2);
+					.map(item => item.trim().toUpperCase());
 			}
 
 			if (


### PR DESCRIPTION
Noticed that only 1 country could be put into the new Shipping method creation. If more than 1 country is put in like the placeholder shows it trimmed the values. Furthermore, the Cezerin Store checkout form validates against all strings in the country conditions array. 