### PR TITLE
Fix home slider to image reference

### DIFF
--- a/config/admin.js
+++ b/config/admin.js
@@ -3,7 +3,6 @@ module.exports = {
 	// dashboard UI language
 	language: process.env.LANGUAGE || 'en',
 	apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:3001/api/v1',
-	assetsBaseURL: process.env.ASSETS_BASE_URL || 'http://localhost:3001',
 	apiWebSocketUrl: process.env.API_WEB_SOCKET_URL || 'ws://localhost:3001',
 	developerMode: process.env.DEVELOPER_MODE || true
 };

--- a/src/modules/settings/themeSettings/components/imageEditor.js
+++ b/src/modules/settings/themeSettings/components/imageEditor.js
@@ -13,24 +13,20 @@ export default class ThemeImageUpload extends React.Component {
 
 	onUpload = formData => {
 		api.theme.assets.uploadFile(formData).then(({ status, json }) => {
-			const fileName = json.file;
-			this.props.input.onChange(fileName);
+			const imageUrl = json.url;
+			this.props.input.onChange(imageUrl);
 		});
 	};
 
 	render() {
 		const { input, label } = this.props;
-		const imageUrl =
-			input.value && input.value.length > 0
-				? `${settings.assetsBaseURL}/assets/images/${input.value}`
-				: null;
 
 		return (
 			<div>
 				<p>{label}</p>
 				<ImageUpload
 					uploading={false}
-					imageUrl={imageUrl}
+					imageUrl={input.value}
 					onDelete={this.onDelete}
 					onUpload={this.onUpload}
 				/>


### PR DESCRIPTION
The home sliders images are not loading.

**Problem**
- The store was managing the asset theme URL, (asset and path information was required to be duplicated across the store and API. Ideally only the API should know about asset paths and this should be passed to the store.)
- The theme settings are stored on the API server in a static JSON file, Its complicated as these are complicated object set by placeholders that define the object structures. 

**Solution**
cezerin2-admin - https://github.com/Cezerin2/cezerin2-admin/pull/31
- Remove asset config reference
- Update image change to reflect asset url

cezerin2-store - https://github.com/Cezerin2/cezerin2-store/pull/33
- Update store_image slider to reference update image object

cezerin2 - https://github.com/Cezerin2/cezerin2/pull/163
- Return asset url with upload complete.
- Add changeProperties for theme settings to append and remove asset url.
- Remove unnecessary footer logo from theme settings.
